### PR TITLE
can: flexcan: use FOSC as primary clock source to flexcan core

### DIFF
--- a/drivers/net/can/flexcan.c
+++ b/drivers/net/can/flexcan.c
@@ -1099,7 +1099,7 @@ static int register_flexcandev(struct net_device *dev)
 	if (err)
 		goto out_disable_per;
 	reg = flexcan_read(&regs->ctrl);
-	reg |= FLEXCAN_CTRL_CLK_SRC;
+	reg &= ~FLEXCAN_CTRL_CLK_SRC;
 	flexcan_write(reg, &regs->ctrl);
 
 	err = flexcan_chip_enable(priv);
@@ -1192,7 +1192,7 @@ static int flexcan_probe(struct platform_device *pdev)
 			dev_err(&pdev->dev, "no per clock defined\n");
 			return PTR_ERR(clk_per);
 		}
-		clock_freq = clk_get_rate(clk_per);
+		clock_freq = 24000000;
 	}
 
 	mem = platform_get_resource(pdev, IORESOURCE_MEM, 0);


### PR DESCRIPTION
This is a very ugly hack and will only work on Vybrid CPU. Need to think
of a better way of doing this so that we can mainline it.

Preferred way is probably a device tree binding.

The FOSC is a 24 MHz oscillator which gets rid of bitrate errors on
flexcan interfaces.

close hostmobility/mx4#211
