### PR TITLE
mmc: sdhci: add sd-detect sysfs entry

### DIFF
--- a/drivers/mmc/host/sdhci.c
+++ b/drivers/mmc/host/sdhci.c
@@ -48,6 +48,9 @@
 static unsigned int debug_quirks = 0;
 static unsigned int debug_quirks2;
 
+struct device_attribute sd_detect_attr;
+static unsigned int sw_sd_detect = 1;
+
 static void sdhci_finish_data(struct sdhci_host *);
 
 static void sdhci_finish_command(struct sdhci_host *);
@@ -141,6 +144,28 @@ static void sdhci_dumpregs(struct sdhci_host *host)
  * Low level functions                                                       *
  *                                                                           *
 \*****************************************************************************/
+static ssize_t sdhci_write_sd_detect_mode (struct device *dev,
+	struct device_attribute *attr, const char *buf, size_t count)
+{
+	unsigned long value;
+
+	if (kstrtoul(buf, 10, &value) < 0){
+		return -EINVAL;
+	}
+
+	sw_sd_detect = value;
+
+	return count;
+}
+
+static int sdhci_create_name_attr(struct device *dev)
+{
+    sysfs_attr_init(&sd_detect_attr.attr);
+    sd_detect_attr.attr.name = "sd_detect";
+    sd_detect_attr.attr.mode = S_IWUGO;
+    sd_detect_attr.store = sdhci_write_sd_detect_mode;
+    return device_create_file(dev, &sd_detect_attr);
+}
 
 static void sdhci_set_card_detection(struct sdhci_host *host, bool enable)
 {
@@ -1645,10 +1670,13 @@ static int sdhci_do_get_cd(struct sdhci_host *host)
 	if (host->flags & SDHCI_DEVICE_DEAD)
 		return 0;
 
-	/* If polling/nonremovable, assume that the card is always present. */
+	/* 	If polling/nonremovable, assume that the card is always present.
+
+		Override with sysfs sw_sd_detect attribute
+	*/
 	if ((host->quirks & SDHCI_QUIRK_BROKEN_CARD_DETECTION) ||
 	    (host->mmc->caps & MMC_CAP_NONREMOVABLE))
-		return 1;
+		return sw_sd_detect;
 
 	/* Try slot gpio detect */
 	if (!IS_ERR_VALUE(gpio_cd))
@@ -3434,6 +3462,14 @@ int sdhci_add_host(struct sdhci_host *host)
 	}
 #endif
 
+	ret = sdhci_create_name_attr(mmc_dev(mmc));
+ 	if (ret) {
+ 		pr_err("%s: Failed to create sd_detect sysfs attribute: %d\n",
+		       mmc_hostname(mmc), ret);
+ 		goto untasklet;
+ 	}
+
+
 	mmiowb();
 
 	mmc_add_host(mmc);
@@ -3485,6 +3521,8 @@ void sdhci_remove_host(struct sdhci_host *host, int dead)
 	}
 
 	sdhci_disable_card_detection(host);
+
+	device_remove_file(mmc_dev(mmc), &sd_detect_attr);
 
 	mmc_remove_host(mmc);
 


### PR DESCRIPTION
In some rather un-usual use cases one might want to control the
sd_detect signal from user space.

One example is following:
- Assume that you do not have a cd_gpio, nor a sd_detect cabability in
  platform sdhci driver. In that case we assume that there is always a
  card present.
- Now assume that in some situations we cut the power-rail to the SD
  card. e.g. when suspend to ram.
- Now when you resume the system we will assume that there is a card
  present, but the power-rail is turned off.
- And above leads that we power some parts of the SD card trough the
  SDIO bus, and when initializing we detect a card but we get the
  following:

[  571.594286] mmc0: host does not support reading read-only switch,
assuming write-enable
[  571.603560] mmc0: new SD card at address d555
[  571.616276] mmcblk0: mmc0:d555 SD032 30.6 MiB

We are expecting a 32 GB card.

In above case I want to disable the sd_detect (polled) until I am sure
that the power rail is on.
