### PR TITLE
ARM: mx4-t30: lower nor clock frequency

### DIFF
--- a/arch/arm/mach-tegra/board-mx4-t30.c
+++ b/arch/arm/mach-tegra/board-mx4-t30.c
@@ -357,7 +357,7 @@ static struct tegra_clk_init_table colibri_t30_clk_init_table[] __initdata = {
 	{"i2s2",	"pll_a_out0",	0,		false},
 	{"i2s3",	"pll_a_out0",	0,		false},
 	{"i2s4",	"pll_a_out0",	0,		false},
-	{"nor",		"pll_p",	127000000,	true},
+	{"nor",		"pll_p",	86500000,	true},
 	{"pll_a",	NULL,		564480000,	true},
 	{"pll_m",	NULL,		0,		false},
 	{"pwm",		"pll_p",	3187500,	false},


### PR DESCRIPTION
127 MHz is maximum rate for the nor bus clock. We seem to be on the edge
of timing requirements when accesing SJA1000 and using 127 MHz. We have
some individuals where we get "bit errrors" on the data read from
SJA1000.

Lower the clock rate to 86,5 MHz which has proven to work without
problems on T20 based boards for a very long time now.

Fixes hostmobility/mx4#306