### PR TITLE
ARM: dts: mx4-c61: change uart in bootargs to ttyLP2

### DIFF
--- a/arch/arm/boot/dts/vf-mx4-c61.dtsi
+++ b/arch/arm/boot/dts/vf-mx4-c61.dtsi
@@ -11,7 +11,7 @@
 
 / {
 	chosen {
-		bootargs = "console=ttyLP0,115200";
+		bootargs = "console=ttyLP2,115200";
 	};
 
 	clk24m: clk24m {


### PR DESCRIPTION
Signed-off-by: Mirza Krak <mirza.krak@hostmobility.com>