### PR TITLE
T30 export pin 129 as input

### DIFF
--- a/arch/arm/mach-tegra/board-mx4-t30.c
+++ b/arch/arm/mach-tegra/board-mx4-t30.c
@@ -483,6 +483,7 @@ static struct gpio colibri_t30_gpios[] = {
 	{TEGRA_GPIO_PJ1,	GPIOF_OUT_INIT_LOW,	"SSP-CAN-CS-D0"},
 	{TEGRA_GPIO_PE7,	GPIOF_OUT_INIT_LOW,	"SSP-CAN-CS-D1"},
 	{TEGRA_GPIO_PF1,	GPIOF_OUT_INIT_LOW,	"SSP-CAN-CS-D2"},
+	{TEGRA_GPIO_PW2,	GPIOF_IN,	        "MODEM-WAKEUP"},
 };
 
 static void colibri_t30_gpio_init(void)


### PR DESCRIPTION
On T20 pin 129 is exported. If this was not fixed on T30 it causes the
level of the pin to be high and interfere with modem.

Tested on 1 T30 and 2 T30-FR with modem issues.
Before fix PWR_IND on modem didn't work until modem had been started
once.