### PR TITLE
arm: dts: mx4-mil: move uartc pinmux to root node

### DIFF
--- a/arch/arm/boot/dts/tegra20-colibri-512.dtsi
+++ b/arch/arm/boot/dts/tegra20-colibri-512.dtsi
@@ -166,6 +166,12 @@
 				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
 				nvidia,tristate = <TEGRA_PIN_ENABLE>;
 			};
+			uartc {
+				nvidia,pins = "uca";
+				nvidia,function = "uartc";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+			};
 			uartd {
 				nvidia,pins = "gmc";
 				nvidia,function = "uartd";

--- a/arch/arm/boot/dts/tegra20-mx4-mil.dtsi
+++ b/arch/arm/boot/dts/tegra20-mx4-mil.dtsi
@@ -63,15 +63,12 @@
 				nvidia,tristate = <TEGRA_PIN_DISABLE>;
 			};
 
-			/* a.k.a uartb */
-			irda {
+			uartc {
 				nvidia,tristate = <TEGRA_PIN_DISABLE>;
 			};
 
-			uartc {
-				nvidia,pins = "uca";
-				nvidia,function = "uartc";
-				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+			/* a.k.a uartb */
+			irda {
 				nvidia,tristate = <TEGRA_PIN_DISABLE>;
 			};
 


### PR DESCRIPTION
It seems that one is not able to add new nodes when "overlaying"
the pinmux node, and one can only modify values in existing
nodes.

This means that the uartc pinmux node had not effect on the pinmux
registers, this was verified by looking at the pinmux register
controlling UARTC function (0xfe000084).

Signed-off-by: Mirza Krak <mirza@mkrak.org>